### PR TITLE
#12 Server private key import/export for stateless implementations

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -10,39 +10,41 @@
     function Server() {}
 
     Server.prototype.init = function(options, callback) {
-      var length;
+      var bBuf, length;
       this.vBuf = new Buffer(options.verifier, 'hex');
       this.saltBuf = new Buffer(options.salt, 'hex');
       length = options.length || 4096;
       this.srp = new SRP(length);
-      return this.srp.b((function(_this) {
-        return function(err, b) {
-          _this.bInt = b;
-          _this.BBuf = _this.srp.B({
-            b: _this.bInt,
-            v: transform.buffer.toBigInteger(_this.vBuf)
-          });
-          return callback();
-        };
-      })(this));
-    };
-
-    Server.prototype.debugInit = function(options, callback) {
-      var length;
-      this.vBuf = new Buffer(options.verifier, 'hex');
-      this.saltBuf = new Buffer(options.salt, 'hex');
-      length = options.length || 4096;
-      this.srp = new SRP(length);
-      this.bInt = transform.buffer.toBigInteger(options.b);
-      this.BBuf = this.srp.B({
-        b: this.bInt,
-        v: transform.buffer.toBigInteger(this.vBuf)
-      });
-      return callback();
+      if (options.b) {
+        bBuf = new Buffer(options.b, 'hex');
+        this.bInt = transform.buffer.toBigInteger(bBuf);
+        this.BBuf = this.srp.B({
+          b: this.bInt,
+          v: transform.buffer.toBigInteger(this.vBuf)
+        });
+        return callback();
+      } else {
+        return this.srp.b((function(_this) {
+          return function(err, b) {
+            _this.bInt = b;
+            _this.BBuf = _this.srp.B({
+              b: _this.bInt,
+              v: transform.buffer.toBigInteger(_this.vBuf)
+            });
+            return callback();
+          };
+        })(this));
+      }
     };
 
     Server.prototype.getPublicKey = function() {
       return this.BBuf.toString('hex');
+    };
+
+    Server.prototype.getPrivateKey = function() {
+      var bBuf;
+      bBuf = transform.bigInt.toBuffer(this.bInt);
+      return bBuf.toString('hex');
     };
 
     Server.prototype.getSalt = function() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsrp",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "JavaScript SRP implementation",
   "main": "jsrp.js",
   "scripts": {

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -11,27 +11,24 @@ class Server
 		length = options.length || 4096;
 		@srp = new SRP length
 
-		@srp.b (err, b) =>
-			@bInt = b
+		if options.b
+			bBuf = new Buffer options.b, 'hex'
+			@bInt = transform.buffer.toBigInteger bBuf
 			@BBuf = @srp.B b: @bInt, v: transform.buffer.toBigInteger @vBuf
-
 			callback()
+		else
+			@srp.b (err, b) =>
+				@bInt = b
+				@BBuf = @srp.B b: @bInt, v: transform.buffer.toBigInteger @vBuf
 
-	debugInit: (options, callback) ->
-		@vBuf = new Buffer options.verifier, 'hex'
-		@saltBuf = new Buffer options.salt, 'hex'
-
-		length = options.length || 4096;
-		@srp = new SRP length
-
-		@bInt = transform.buffer.toBigInteger options.b
-		@BBuf = @srp.B b: @bInt, v: transform.buffer.toBigInteger @vBuf
-
-		callback()
-
+				callback()
 
 	getPublicKey: () ->
 		return @BBuf.toString 'hex'
+
+	getPrivateKey: () ->
+		bBuf = transform.bigInt.toBuffer @bInt
+		return bBuf.toString 'hex'
 
 	getSalt: () ->
 		return @saltBuf.toString 'hex'

--- a/test/rfc5054.coffee
+++ b/test/rfc5054.coffee
@@ -55,11 +55,11 @@ describe 'RFC 5054', ->
             done
 
     it 'initialize server', (done) ->
-        server.debugInit
+        server.init
             salt: s.toString('hex'),
             verifier: v_expected.toString('hex'),
             length: 1024,
-            b: b,
+            b: b.toString('hex'),
             done
 
     it 'v', ->


### PR DESCRIPTION
- add b parameter to `server.init()` options
- remove `server.debugInit()`
- update tests to use `server.init()` instead of `server.debugInit()`
- update version number