### PR TITLE
Added compatibility mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ client.getSharedKey() === server.getSharedKey() // will be true
 `Client` methods:
 
 - **`init(options, callback)`**
-	- `options` should be an object containing a username and a password. `{ username: 'username', password: 'password' }`. You may also pass a length property, which will allow you to select  the size of your parameters. It defaults to 4096.
+	- `options` should be an object containing a username and a password. `{ username: 'username', password: 'password' }`. 
+	    - You may also pass a `length` property, which will allow you to select  the size of your parameters. It defaults to 4096. 
+	    - You may also pass a `compatibility` property (Boolean). If set to true, proofs will be generated with ***S*** instead of ***K*** to be compatible with specific other SRP implementations.
 	- `callback` will be called when the client instance is ready to use.
 - **`getPublicKey() -> Hex A value`**
 	- Return the hex representation of the client's ***A*** value, suitable for sending over the network.

--- a/lib/client.js
+++ b/lib/client.js
@@ -13,6 +13,7 @@
       var length;
       this.IBuf = Buffer.from(options.username);
       this.PBuf = Buffer.from(options.password);
+      this.compatibility = options.compatibility === true;
       length = options.length || 4096;
       this.srp = new SRP(length);
       return this.srp.a((err, a) => {
@@ -29,6 +30,7 @@
       var length;
       this.IBuf = Buffer.from(options.username);
       this.PBuf = Buffer.from(options.password);
+      this.compatibility = options.compatibility === true;
       length = options.length || 4096;
       this.srp = new SRP(length);
       this.aInt = transform.buffer.toBigInteger(options.a);
@@ -82,11 +84,19 @@
 
     // Get our M1 in Hex value to send to the server for verification.
     getProof() {
-      this.M1Buf = this.srp.M1({
-        A: this.ABuf,
-        B: this.BBuf,
-        K: this.KBuf
-      });
+      if (this.compatibility) {
+        this.M1Buf = this.srp.M1({
+          A: this.ABuf,
+          B: this.BBuf,
+          K: this.SBuf
+        });
+      } else {
+        this.M1Buf = this.srp.M1({
+          A: this.ABuf,
+          B: this.BBuf,
+          K: this.KBuf
+        });
+      }
       return this.M1Buf.toString('hex');
     }
 
@@ -94,11 +104,19 @@
     checkServerProof(hexM2) {
       var ServerM2Buf, result;
       ServerM2Buf = Buffer.from(hexM2, 'hex');
-      this.M2Buf = this.srp.M2({
-        A: this.ABuf,
-        M: this.M1Buf,
-        K: this.KBuf
-      });
+      if (this.compatibility) {
+        this.M2Buf = this.srp.M2({
+          A: this.ABuf,
+          M: this.M1Buf,
+          K: this.SBuf
+        });
+      } else {
+        this.M2Buf = this.srp.M2({
+          A: this.ABuf,
+          M: this.M1Buf,
+          K: this.KBuf
+        });
+      }
       result = this.M2Buf.toString('hex') === ServerM2Buf.toString('hex');
       return result;
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -12,6 +12,7 @@
       var bBuf, length;
       this.vBuf = Buffer.from(options.verifier, 'hex');
       this.saltBuf = Buffer.from(options.salt, 'hex');
+      this.compatibility = options.compatibility === true;
       length = options.length || 4096;
       this.srp = new SRP(length);
       if (options.b) {
@@ -80,22 +81,38 @@
     checkClientProof(M1hex) {
       var clientM1Buf, result;
       clientM1Buf = Buffer.from(M1hex, 'hex');
-      this.M1Buf = this.srp.M1({
-        A: this.ABuf,
-        B: this.BBuf,
-        K: this.KBuf
-      });
+      if (this.compatibility) {
+        this.M1Buf = this.srp.M1({
+          A: this.ABuf,
+          B: this.BBuf,
+          K: this.SBuf
+        });
+      } else {
+        this.M1Buf = this.srp.M1({
+          A: this.ABuf,
+          B: this.BBuf,
+          K: this.KBuf
+        });
+      }
       result = this.M1Buf.toString('hex') === clientM1Buf.toString('hex');
       return result;
     }
 
     getProof() {
       var result;
-      this.M2Buf = this.srp.M2({
-        A: this.ABuf,
-        M: this.M1Buf,
-        K: this.KBuf
-      });
+      if (this.compatibility) {
+        this.M2Buf = this.srp.M2({
+          A: this.ABuf,
+          M: this.M1Buf,
+          K: this.SBuf
+        });
+      } else {
+        this.M2Buf = this.srp.M2({
+          A: this.ABuf,
+          M: this.M1Buf,
+          K: this.KBuf
+        });
+      }
       result = this.M2Buf.toString('hex');
       return result;
     }

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -8,6 +8,7 @@ class Client
 	init: (options, callback) ->
 		@IBuf = Buffer.from options.username
 		@PBuf = Buffer.from options.password
+		@compatibility = options.compatibility == true
 
 		length = options.length || 4096;
 		@srp = new SRP length
@@ -22,6 +23,7 @@ class Client
 	debugInit: (options, callback) ->
 		@IBuf = Buffer.from options.username
 		@PBuf = Buffer.from options.password
+		@compatibility = options.compatibility == true
 
 		length = options.length || 4096;
 		@srp = new SRP length
@@ -66,13 +68,20 @@ class Client
 
 	# Get our M1 in Hex value to send to the server for verification.
 	getProof: () ->
-		@M1Buf = @srp.M1 A: @ABuf, B: @BBuf, K: @KBuf
+		if @compatibility
+			@M1Buf = @srp.M1 A: @ABuf, B: @BBuf, K: @SBuf
+		else
+			@M1Buf = @srp.M1 A: @ABuf, B: @BBuf, K: @KBuf
+
 		return @M1Buf.toString 'hex'
 
 	# Allow us to verify the server's M2 response.
 	checkServerProof: (hexM2) ->
 		ServerM2Buf = Buffer.from hexM2, 'hex'
-		@M2Buf = @srp.M2 A: @ABuf, M: @M1Buf, K: @KBuf
+		if @compatibility
+			@M2Buf = @srp.M2 A: @ABuf, M: @M1Buf, K: @SBuf
+		else
+			@M2Buf = @srp.M2 A: @ABuf, M: @M1Buf, K: @KBuf
 
 		result = @M2Buf.toString('hex') is ServerM2Buf.toString('hex')
 		return result

--- a/src/server.coffee
+++ b/src/server.coffee
@@ -7,6 +7,7 @@ class Server
 	init: (options, callback) ->
 		@vBuf = Buffer.from options.verifier, 'hex'
 		@saltBuf = Buffer.from options.salt, 'hex'
+		@compatibility = options.compatibility == true
 
 		length = options.length || 4096;
 		@srp = new SRP length
@@ -59,13 +60,19 @@ class Server
 
 	checkClientProof: (M1hex) ->
 		clientM1Buf = Buffer.from M1hex, 'hex'
-		@M1Buf = @srp.M1 A: @ABuf, B: @BBuf, K: @KBuf
+		if @compatibility
+			@M1Buf = @srp.M1 A: @ABuf, B: @BBuf, K: @SBuf
+		else
+			@M1Buf = @srp.M1 A: @ABuf, B: @BBuf, K: @KBuf
 
 		result = @M1Buf.toString('hex') is clientM1Buf.toString('hex')
 		return result
 
 	getProof: () ->
-		@M2Buf = @srp.M2 A: @ABuf, M: @M1Buf, K: @KBuf
+		if @compatibility
+			@M2Buf = @srp.M2 A: @ABuf, M: @M1Buf, K: @SBuf
+		else
+			@M2Buf = @srp.M2 A: @ABuf, M: @M1Buf, K: @KBuf
 
 		result = @M2Buf.toString('hex')
 		return result

--- a/test/compatibility.coffee
+++ b/test/compatibility.coffee
@@ -1,0 +1,59 @@
+assert = require 'assert'
+should = require 'should'
+SRPClient = require '../src/client'
+SRPServer = require '../src/server'
+transform = require '../src/transform'
+client = new SRPClient()
+server = new SRPServer()
+
+I = Buffer.from "alice"
+P = Buffer.from "password123"
+s = Buffer.from 'beb25379d1a8581eb5a727673a2441ee', 'hex'
+a = Buffer.from '60975527035cf2ad1989806f0407210bc81edc04e2762a56afd529ddda2d4393', 'hex'
+b = Buffer.from 'e487cb59d31ac550471e81f00f6928e01dda08e974a004f49e61f5d105284d20', 'hex'
+
+v_static = '7e273de8 696ffc4f 4e337d05 b4b375be b0dde156 9e8fa00a 9886d812
+            9bada1f1 822223ca 1a605b53 0e379ba4 729fdc59 f105b478 7e5186f5
+            c671085a 1447b52a 48cf1970 b4fb6f84 00bbf4ce bfbb1681 52e08ab5
+            ea53d15c 1aff87b2 b9da6e04 e058ad51 cc72bfc9 033b564e 26480d78
+            e955a5e2 9e7ab245 db2be315 e2099afb'
+
+v_static = transform.cleanHex v_static
+
+init = () ->
+  await new Promise (resolve) ->
+    client.debugInit
+      username: I.toString('utf8'),
+      password: P.toString('utf8'),
+      length: 1024,
+      a: a,
+      compatibility: true,
+      resolve
+
+  await new Promise (resolve) ->
+    server.init
+      salt: s.toString('hex'),
+      verifier: v_static,
+      length: 1024,
+      b: b.toString('hex'),
+      compatibility: true,
+      resolve
+
+  client.setSalt s.toString('hex')
+  client.setServerPublicKey server.getPublicKey()
+  server.setClientPublicKey client.getPublicKey()
+
+init()
+
+describe 'Compatibility mode', ->
+  describe 'Client proof', ->
+    it 'was calculated with S', ->
+      clientProof = client.getProof()
+      clientProof.should.equal 'b46a783846b7e569ff8f9b44ab8d88edeb085a65'
+      server.checkClientProof(clientProof).should.be.true()
+
+  describe 'Server proof', ->
+    it 'was calculated with S', ->
+      serverProof = server.getProof()
+      serverProof.should.equal('0b0a6ad3024e79b5cad04042abb3a3f592d20c17')
+      client.checkServerProof(serverProof).should.be.true()


### PR DESCRIPTION
Some libraries use S instead of K for proof generation.
The optional compatibility flag is meant to enable communication with those implementations.